### PR TITLE
Adds in the ability to specify an output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,25 @@ If you do not have these commands, [Homebrew](http://brew.sh) makes it easy to i
 
 ## Usage
 
-`movie-barcode.sh [PATH_TO_MOVIE] [FRAMES_TO_EXRACT=2000]`
+`./movie-barcode [PATH_TO_MOVIE] [FRAMES_TO_EXRACT=2000] [OUTPUT_FILENAME=$MOVIE_BASENAME]`
 
 ## Sample
 
 **Movie: Scarface (1983)**
 
-`movie-barcode.sh "$HOME/Movies/Scarface (1983).mp4" 2000`
+`./movie-barcode "$HOME/Movies/Scarface (1983).mp4" 2000`
 
 ![Movie Barcode of Scarface](https://raw.githubusercontent.com/tyler-king/movie-barcode/master/samples/scarface.jpg)
 
+Would output a file named `Scarface_(1983).mp4.jpg` in the same directory as the movie-barcode executable.
+
 **Music: DMX - I Don't Dance**
 
-`movie-barcode.sh "$HOME/Downloads/DMX - I Dont Dance.mp4" 2000`
+`movie-barcode.sh "$HOME/Downloads/DMX - I Dont Dance.mp4" 2000 i_dont_dance.jpg`
 
 ![Movie Barcode of DMX](https://raw.githubusercontent.com/tyler-king/movie-barcode/master/samples/dmx.jpg)
+
+Would output a file named `i_dont_dance.jpg` in the same directory as the movie-barcode executable.
 
 ## Output
 

--- a/movie-barcode
+++ b/movie-barcode
@@ -16,6 +16,14 @@ if [ $2 ]; then
   MOVIE_FRAMES=$2
 fi;
 
+OUTPUT_FILENAME="$(basename $MOVIE_PATH).jpg"
+
+if [ $3 ]; then
+  OUTPUT_FILENAME=$3
+fi;
+
+OUTPUT_FILENAME="${OUTPUT_FILENAME//[[:space:]]/_}"
+
 echo "--- Movie Barcode Generator ---"
 echo "Movie: $(basename "$MOVIE_PATH")"
 echo "Frames: $MOVIE_FRAMES"
@@ -41,9 +49,9 @@ echo "Resizing complete!"
 echo ""
 echo "3. Creating final image..."
 
-convert `ls -c tmp/image-*.jpg` -set colorspace RGB +append barcode.jpg &>/dev/null
-mogrify -gravity center -crop "$MOVIE_FRAMES"x1000+0+0 barcode.jpg &>/dev/null
+convert `ls -c tmp/image-*.jpg` -set colorspace RGB +append $OUTPUT_FILENAME &>/dev/null
+mogrify -gravity center -crop "$MOVIE_FRAMES"x1000+0+0 $OUTPUT_FILENAME &>/dev/null
 
-echo "Movie barcode created (barcode.jpg)!"
+echo "Movie barcode created ($OUTPUT_FILENAME)!"
 
 rm ./tmp/*.jpg


### PR DESCRIPTION
By default, it no longer just outputs as barcode.jpg

It will output the filename of the file with a .jpg suffix

This can be overridden with a 3rd argument to specify where output to

Thinking of adding an `output/` directory that can store the generated files by default as well, ignore the contents but keep the directory so it's there without having to create it if it doesn't exist in the script.

PS: Thanks for this little script :)
